### PR TITLE
Correction of errors in the README file for postgresql

### DIFF
--- a/db_optimization/lab01/postresql/README.md
+++ b/db_optimization/lab01/postresql/README.md
@@ -8,16 +8,18 @@
 7. Стоврити процедуру з update_managers.sql
 8. Виконати наступний запит 
 ```
-begin
+DO $$
+BEGIN
     CALL INSERT_VALUES_INTO_CITIES();
     CALL INSERT_VALUES_INTO_EMPLOYEES();
-end;
+END $$;
 ```
 8. Виконати запит
 ```
-begin
+DO $$
+BEGIN
     CALL UPDATE_MANAGERS(100000, 8);
-end;
+END $$;
 ```
 9. Виконати запит для представлення ієрархії
 ```

--- a/db_optimization/lab01/postresql/README.md
+++ b/db_optimization/lab01/postresql/README.md
@@ -21,9 +21,18 @@ end;
 ```
 9. Виконати запит для представлення ієрархії
 ```
-SELECT LPAD(' ', (LEVEL-1) * 2) || FIRST_NAME || ' ' || LAST_NAME AS EMPLOYEE_NAME, level
-from EMPLOYEES
-start with id = 1
-connect by nocycle PRIOR id = MANAGER_ID;
+WITH RECURSIVE employee_tree AS (
+  SELECT id, first_name, last_name, manager_id, 1 AS level
+  FROM employees
+  WHERE id = 1
+  
+  UNION ALL
+
+  SELECT e.id, e.first_name, e.last_name, e.manager_id, et.level + 1
+  FROM employees e
+  JOIN employee_tree et ON e.manager_id = et.id
+)
+SELECT LPAD(' ', (level - 1) * 2) || first_name || ' ' || last_name AS employee_name, level
+FROM employee_tree;
 ```
 10. Кожну дію Ви маєте розуміти і пояснити

--- a/db_optimization/lab01/postresql/README.md
+++ b/db_optimization/lab01/postresql/README.md
@@ -2,20 +2,21 @@
 1. Підключитися до БД
 2. Виконати EMPLOYEES.sql
 3. Виконати CITIES.sql
-4. Виконати insert_values_into_cities.sql
-5. Виконати generate_random_phone_number.sql
-6. Виконати insert_values_into_cities.sql
-7. Виконати запит 
+4. Створити процедуру з insert_values_into_cities.sql
+5. Створити процедуру з generate_random_phone_number.sql
+6. Створити процедуру з insert_values_into_employees.sql
+7. Стоврити процедуру з update_managers.sql
+8. Виконати наступний запит 
 ```
 begin
-    INSERT_VALUES_INTO_CITIES();
-    INSERT_VALUES_INTO_EMPLOYEES();
+    CALL INSERT_VALUES_INTO_CITIES();
+    CALL INSERT_VALUES_INTO_EMPLOYEES();
 end;
 ```
 8. Виконати запит
 ```
 begin
-    UPDATE_MANAGERS(100000, 8);
+    CALL UPDATE_MANAGERS(100000, 8);
 end;
 ```
 9. Виконати запит для представлення ієрархії


### PR DESCRIPTION
Доброго вечора.
Помітив деякі помилки й незрозумілості описані в README файлі для налаштування postgresql, тому виправив їх. Останній запит для відображення ієрархії працює тільки в Oracle, тому для postgresql він був суттєво змінений